### PR TITLE
This should add a label for merge on green

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # actions
 
+Things using GitHub actions
+
 Currently:
 
 - PRs get a Danger JS run
@@ -9,3 +11,4 @@ TODO:
 
 - On a green status, merge if the label applies - [src](https://github.com/artsy/peril-settings/blob/master/org/mergeOnGreen.ts)
 - Get danger-swift working
+


### PR DESCRIPTION
```
Error:  Error: repoSlug was called on GitHubActions when it wasn't a PR
at GitHubActions.get [as repoSlug] (/github/home/.npm/_npx/1/lib/node_modules/danger/distribution/ci_source/providers/GitHubActions.js:69:19)
at GitHubAPI.<anonymous> (/github/home/.npm/_npx/1/lib/node_modules/danger/distribution/platforms/github/GitHubAPI.js:397:50)
at step (/github/home/.npm/_npx/1/lib/node_modules/danger/distribution/platforms/github/GitHubAPI.js:43:23)
at Object.next (/github/home/.npm/_npx/1/lib/node_modules/danger/distribution/platforms/github/GitHubAPI.js:24:53)
at /github/home/.npm/_npx/1/lib/node_modules/danger/distribution/platforms/github/GitHubAPI.js:18:71
at new Promise (<anonymous>)
at __awaiter (/github/home/.npm/_npx/1/lib/node_modules/danger/distribution/platforms/github/GitHubAPI.js:14:12)
at GitHubAPI.getPullRequestDiff (/github/home/.npm/_npx/1/lib/node_modules/danger/distribution/platforms/github/GitHubAPI.js:392:56)
at Object.<anonymous> (/github/home/.npm/_npx/1/lib/node_modules/danger/distribution/platforms/github/GitHubGit.js:65:50)
at step (/github/home/.npm/_npx/1/lib/node_modules/danger/distribution/platforms/github/GitHubGit.js:32:23)

```